### PR TITLE
merge optimizations from thermidity

### DIFF
--- a/bitmaps.h
+++ b/bitmaps.h
@@ -9,6 +9,7 @@
 #define BITMAPS_H
 
 #include <stdint.h>
+#include "types.h"
 
 #define TUX 0
 #define LINUS 1
@@ -18,9 +19,9 @@
  */
 typedef struct {
     /** Width of the bitmap, must be a multiple of 8. */
-    const uint16_t width;
+    const width_t width;
     /** Height of the bitmap, must be a multiple of 8. */
-    const uint16_t height;
+    const height_t height;
     /** The actual bitmap. */
     const __flash uint8_t *bitmap;
 } Bitmap;

--- a/display.h
+++ b/display.h
@@ -8,6 +8,8 @@
 #ifndef DISPLAY_H
 #define DISPLAY_H
 
+#include "types.h"
+#include "bitmaps.h"
 #include "font.h"
 
 /**
@@ -30,7 +32,7 @@ void setFrame(uint8_t byte);
  * @param index
  * @return bitmap width
  */
-uint8_t writeBitmap(uint16_t row, uint16_t col, uint16_t index);
+width_t writeBitmap(row_t row, col_t col, uint16_t index);
 
 /**
  * Writes the glyph with the given pseudo UTF-8 code point with the given
@@ -41,7 +43,7 @@ uint8_t writeBitmap(uint16_t row, uint16_t col, uint16_t index);
  * @param code
  * @return glyph width
  */
-uint8_t writeChar(uint16_t row, uint16_t col, Font font, uint16_t code);
+width_t writeGlyph(row_t row, col_t col, const __flash Font *font, code_t code);
 
 /**
  * Writes the given string with the given font to the given row and column.
@@ -50,7 +52,7 @@ uint8_t writeChar(uint16_t row, uint16_t col, Font font, uint16_t code);
  * @param font
  * @param string
  */
-void writeString(uint16_t row, uint16_t col, const __flash Font *font, char *string);
+void writeString(row_t row, col_t col, const __flash Font *font, char *string);
 
 /**
  * Displays a demo for the awesome Unifont.

--- a/font.c
+++ b/font.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include "font.h"
 
-const __flash Glyph* getGlyphAddress(const __flash Font *font, uint16_t code) {
+const __flash Glyph* getGlyphAddress(const __flash Font *font, code_t code) {
     
     // https://en.wikipedia.org/wiki/Binary_search_algorithm
     int16_t l = 0;

--- a/font.h
+++ b/font.h
@@ -8,14 +8,16 @@
 #ifndef FONT_H
 #define FONT_H
 
+#include "types.h"
+
 /**
  * A glyph with its pseudo UTF-8 code point, width and bitmap.
  */
 typedef struct {
     /** Pseudo UTF-8 code point of the glyph. */
-    const uint16_t code;
+    const code_t code;
     /** Width of the glyph. */
-    const uint8_t width;
+    const width_t width;
     /** Bitmap of the glyph. */
     const __flash uint8_t *bitmap;
 } Glyph;
@@ -30,7 +32,7 @@ typedef struct {
     /** Number of glyphs of this font. */
     const uint8_t length;
     /** Height of (the glyphs of) this font. */
-    const uint8_t height;
+    const height_t height;
 } Font;
 
 /**
@@ -41,6 +43,6 @@ typedef struct {
  * @param code
  * @return Glyph
  */
-const __flash Glyph* getGlyphAddress(const __flash Font *font, uint16_t code);
+const __flash Glyph* getGlyphAddress(const __flash Font *font, code_t code);
 
 #endif /* FONT_H */

--- a/sram.c
+++ b/sram.c
@@ -20,19 +20,17 @@ void sramWrite(uint16_t address, uint8_t data) {
     sramDes();
 }
 
-size_t sramWriteString(uint16_t startAddress, char *data) {
-    size_t length = strlen(data);
+size_t sramWriteString(uint16_t address, const char *data) {
     size_t written = 0;
-    for (size_t i = 0; i < length; i++) {
-        uint16_t address = startAddress + i;
+    for (; address <= SRAM_HIGH; ++address) {
         char c = *data++;
-        sramWrite(address, c);
-        written++;
-        if (address == SRAM_HIGH) {
+        if (c == 0) {
             break;
         }
+        sramWrite(address, c);
+        written++;
     }
-
+    
     return written;
 }
 
@@ -47,13 +45,12 @@ uint8_t sramRead(uint16_t address) {
     return read;
 }
 
-void sramReadString(uint16_t startAddress, char *buf, size_t length) {
+void sramReadString(uint16_t address, char *buf, size_t length) {
     for (size_t i = 0; i < length - 1; i++) {
-        uint16_t address = startAddress + i;
-        buf[i] = sramRead(address);
-        if (address == SRAM_HIGH) {
+        if (address > SRAM_HIGH) {
             break;
         }
+        buf[i] = sramRead(address++);
     }
     buf[length - 1] = '\0';
 }

--- a/sram.h
+++ b/sram.h
@@ -30,11 +30,11 @@ void sramWrite(uint16_t address, uint8_t data);
  * Writes the given string starting at the given address, never beyond
  * the highest memory address, and returns the number of bytes actually
  * written.
- * @param startAddress
+ * @param address
  * @param data
  * @return number of bytes written
  */
-size_t sramWriteString(uint16_t startAddress, char *data);
+size_t sramWriteString(uint16_t address, const char *data);
 
 /**
  * Reads the byte at the given address and returns it.
@@ -47,11 +47,11 @@ uint8_t sramRead(uint16_t address);
  * Reads length - 1 bytes starting at the given address, never beyond 
  * the highest memory address, into the given buffer and adds a trailing 
  * null terminator.
- * @param startAddress
+ * @param address
  * @param string
  * @param length
  */
-void sramReadString(uint16_t startAddress, char *string, size_t length);
+void sramReadString(uint16_t address, char *string, size_t length);
 
 /**
  * Writes the given status.

--- a/types.h
+++ b/types.h
@@ -1,0 +1,23 @@
+/* 
+ * File:   types.h
+ * Author: torsten.roemer@luniks.net
+ *
+ * Created on 17. September 2023, 20:33
+ */
+
+#ifndef TYPES_H
+#define TYPES_H
+
+/* Width and height of bitmaps and glyphs */
+typedef uint8_t width_t;
+typedef uint8_t height_t;
+
+/* Number of rows and columns of the display */
+typedef uint8_t row_t;
+typedef uint8_t col_t;
+
+/* Font code (like UTF-8 code point) */
+typedef uint8_t code_t;
+
+#endif /* TYPES_H */
+


### PR DESCRIPTION
- avoid frequent, expensive divisions
- use 'typedef uint8_t code_t' for char codes instead of uint16_t
- use 'typedef uint8_t height_t' for bitmap height instead of uint16_t, same for width, row, col
- put shared types in 'types.h'
- optimize writing strings to and reading strings from SRAM (not used)